### PR TITLE
Release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Release 5.1.0 (April 20, 2024)
+
+* Added an additional `distance` method to `DistanceCalulator`.  You can now pass a `List` of points rather than being required to use vararg/array
+* `DistanceCalculator` has been updated to use [NASA's latest figure](https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html) for Earth's radius (revised down from 6371.008 km to 6371.0 km)
+* Mockito is no longer a test dependency
+* Fixed Spotbugs failure regarding newline platform independence
+
 # Release 5.0.0 (April 3, 2024)
 
 * Removed dependencies on my external `BuildScripts` and `NumberUtil` projects

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
 }
 
 plugins {
-   id("java")
-   id("com.github.spotbugs") version "6.0.10"
-   id("maven-publish")
+   id "java"
+   id "com.github.spotbugs" version "6.0.10"
+   id "maven-publish"
 }
 
 sourceCompatibility = javaSourceCompatibility
@@ -20,7 +20,6 @@ repositories {
 dependencies {
    testImplementation platform("org.junit:junit-bom:5.10.2")
    testImplementation "org.junit.jupiter:junit-jupiter"
-   testImplementation "org.mockito:mockito-junit-jupiter:5.11.0"
    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 

--- a/src/main/java/org/loverde/geographiccoordinate/Latitude.java
+++ b/src/main/java/org/loverde/geographiccoordinate/Latitude.java
@@ -130,6 +130,6 @@ public record Latitude(int degrees, int minutes, double seconds, Direction direc
     }
 
     public static String getRangeError() {
-        return LAT_LON_RANGE_ERROR.formatted(MAX_VALUE, MAX_VALUE, (int) MAX_VALUE, (int) MAX_VALUE);
+        return LAT_LON_RANGE_ERROR.replaceAll("\n", "%n").formatted(MAX_VALUE, MAX_VALUE, (int) MAX_VALUE, (int) MAX_VALUE);
     }
 }

--- a/src/main/java/org/loverde/geographiccoordinate/Longitude.java
+++ b/src/main/java/org/loverde/geographiccoordinate/Longitude.java
@@ -130,6 +130,6 @@ public record Longitude (int degrees, int minutes, double seconds, Longitude.Dir
     }
 
     public static String getRangeError() {
-        return LAT_LON_RANGE_ERROR.formatted(MAX_VALUE, MAX_VALUE, (int) MAX_VALUE, (int) MAX_VALUE);
+        return LAT_LON_RANGE_ERROR.replaceAll("\n", "%n").formatted(MAX_VALUE, MAX_VALUE, (int) MAX_VALUE, (int) MAX_VALUE);
     }
 }

--- a/src/main/java/org/loverde/geographiccoordinate/calculator/BearingCalculator.java
+++ b/src/main/java/org/loverde/geographiccoordinate/calculator/BearingCalculator.java
@@ -103,7 +103,7 @@ public class BearingCalculator {
     }
 
     private static <T extends CompassDirection> Bearing<T> newBearing(final Class<T> compassType, final BigDecimal angle) {
-        failIf(compassType == null, () -> COMPASS_TYPE_NULL);
+        failIf(compassType == null, COMPASS_TYPE_NULL);
 
         if (compassType.equals(CompassDirection8.class)) {
             return new Bearing(CompassDirection8.getByBearing(angle), angle);
@@ -117,8 +117,8 @@ public class BearingCalculator {
     }
 
     private static BigDecimal calculateBearing(final Point from, final Point to) {
-        failIf(from == null, () -> STARTING_POINT_NULL);
-        failIf(to == null, () -> BEARING_TO_NULL);
+        failIf(from == null, STARTING_POINT_NULL);
+        failIf(to == null, BEARING_TO_NULL);
 
         final double fromLatRadians = from.latitude().toRadians(),
                      fromLonRadians = from.longitude().toRadians(),
@@ -139,7 +139,7 @@ public class BearingCalculator {
         final BigDecimal zeroedBearing;
         BigDecimal backAzimuth;
 
-        failIf(bearing == null, () -> BEARING_NULL);
+        failIf(bearing == null, BEARING_NULL);
         failIf(bearing.compareTo(ZERO) < 0 || bearing.compareTo(BD_360) > 0, () -> BEARING_OUT_OF_RANGE.formatted(bearing.toPlainString()));
 
         zeroedBearing = bearing.compareTo(BD_360) == 0 ? ZERO : bearing;

--- a/src/main/java/org/loverde/geographiccoordinate/internal/Objects.java
+++ b/src/main/java/org/loverde/geographiccoordinate/internal/Objects.java
@@ -15,4 +15,15 @@ public class Objects {
             throw new IllegalArgumentException(iaeMessage.get());
         }
     }
+
+    /**
+     * Shorthand for IF statements that throw IllegalArgumentException
+     * @param isFailed The result of the check
+     * @param iaeMessage Exception message
+     */
+    public static void failIf(final boolean isFailed, final String iaeMessage) {
+        if (isFailed) {
+            throw new IllegalArgumentException(iaeMessage);
+        }
+    }
 }

--- a/src/test/java/org/loverde/geographiccoordinate/calculator/BearingCalculatorTest.java
+++ b/src/test/java/org/loverde/geographiccoordinate/calculator/BearingCalculatorTest.java
@@ -36,15 +36,15 @@ package org.loverde.geographiccoordinate.calculator;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.loverde.geographiccoordinate.calculator.BearingCalculator.backAzimuth;
 import static org.loverde.geographiccoordinate.calculator.BearingCalculator.initialBearing;
-import static org.loverde.geographiccoordinate.exception.ExceptionMessages.*;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+import static org.loverde.geographiccoordinate.exception.ExceptionMessages.BEARING_NULL;
+import static org.loverde.geographiccoordinate.exception.ExceptionMessages.BEARING_OUT_OF_RANGE;
+import static org.loverde.geographiccoordinate.exception.ExceptionMessages.COMPASS_TYPE_NULL;
+import static org.loverde.geographiccoordinate.exception.ExceptionMessages.STARTING_POINT_NULL;
 
 import java.math.BigDecimal;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.loverde.geographiccoordinate.Bearing;
 import org.loverde.geographiccoordinate.Latitude;
 import org.loverde.geographiccoordinate.Longitude;
@@ -53,17 +53,12 @@ import org.loverde.geographiccoordinate.compass.CompassDirection16;
 import org.loverde.geographiccoordinate.compass.CompassDirection32;
 import org.loverde.geographiccoordinate.compass.CompassDirection8;
 import org.loverde.geographiccoordinate.exception.ExceptionMessages;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 
-@ExtendWith(MockitoExtension.class)
 class BearingCalculatorTest {
 
-    @Mock
     private Point point1;
 
-    @Mock
     private Point point2;
 
 
@@ -75,11 +70,8 @@ class BearingCalculatorTest {
         final Latitude latitude2 = new Latitude(38, 54, 17, Latitude.Direction.NORTH);
         final Longitude longitude2 = new Longitude(77, 0, 59, Longitude.Direction.WEST);
 
-        lenient().when(point1.latitude()).thenReturn(latitude1);
-        lenient().when(point1.longitude()).thenReturn(longitude1);
-
-        lenient().when(point2.latitude()).thenReturn(latitude2);
-        lenient().when(point2.longitude()).thenReturn(longitude2);
+        point1 = new Point(latitude1, longitude1);
+        point2 = new Point(latitude2, longitude2);
     }
 
     @Test
@@ -89,41 +81,9 @@ class BearingCalculatorTest {
     }
 
     @Test
-    void initialBearing_nullFromLatitude() {
-        when(point1.latitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> initialBearing(CompassDirection8.class, point1, point2));
-        assertEquals(BEARING_FROM_LATITUDE_NULL, e.getMessage());
-    }
-
-    @Test
-    void initialBearing_nullFromLongitude() {
-        when(point1.longitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> initialBearing(CompassDirection8.class, point1, point2));
-        assertEquals(BEARING_FROM_LONGITUDE_NULL, e.getMessage());
-    }
-
-    @Test
     void initialBearing_nullFromPoint() {
         Exception e = assertThrows(IllegalArgumentException.class, () -> initialBearing(CompassDirection8.class, null, point2));
         assertEquals(STARTING_POINT_NULL, e.getMessage());
-    }
-
-    @Test
-    void initialBearing_nullToLatitude() {
-        when(point2.latitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> initialBearing(CompassDirection8.class, point1, point2));
-        assertEquals(BEARING_TO_LATITUDE_NULL, e.getMessage());
-    }
-
-    @Test
-    void initialBearing_nullToLongitude() {
-        when(point2.longitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> initialBearing(CompassDirection8.class, point1, point2));
-        assertEquals(BEARING_TO_LONGITUDE_NULL, e.getMessage());
     }
 
     @Test

--- a/src/test/java/org/loverde/geographiccoordinate/calculator/DistanceCalculatorTest.java
+++ b/src/test/java/org/loverde/geographiccoordinate/calculator/DistanceCalculatorTest.java
@@ -35,27 +35,22 @@ package org.loverde.geographiccoordinate.calculator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.loverde.geographiccoordinate.Latitude;
 import org.loverde.geographiccoordinate.Longitude;
 import org.loverde.geographiccoordinate.Point;
 import org.loverde.geographiccoordinate.calculator.DistanceCalculator.Unit;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.loverde.geographiccoordinate.calculator.DistanceCalculator.distance;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 
-@ExtendWith(MockitoExtension.class)
 class DistanceCalculatorTest {
 
-    private Point point1, point2;
-
-    @Mock
-    private Point mockPoint;
+    private Point point1;
+    private Point point2;
 
     private static final double fpDelta = 1E-15;
 
@@ -70,9 +65,6 @@ class DistanceCalculatorTest {
 
         point1 = new Point(latitude1, longitude1);
         point2 = new Point(latitude2, longitude2);
-
-        lenient().when(mockPoint.latitude()).thenReturn(latitude1);
-        lenient().when(mockPoint.longitude()).thenReturn(longitude1);
     }
 
     @Test
@@ -90,131 +82,77 @@ class DistanceCalculatorTest {
     @Test
     void distance_nullPoint() {
         Exception e = assertThrows(IllegalArgumentException.class, () -> distance(Unit.KILOMETERS, null, point2));
-        assertEquals("points 0 is null", e.getMessage());
-    }
-
-    /**
-     * {@linkplain Point}'s constructor doesn't allow null {@linkplain Latitude} or {@linkplain Longitude},
-     * and the class is immutable.  If that were to change, we need to know that DistanceCalculator detects
-     * nulls, so this test uses Mockito to force Point to return a null.
-     */
-    @Test
-    void distance_nullLatitudePoint1() {
-        when(mockPoint.latitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> distance(Unit.KILOMETERS, mockPoint, point2));
-        assertEquals("Latitude 1 is null", e.getMessage());
-    }
-
-    /**
-     * {@linkplain Point}'s constructor doesn't allow null {@linkplain Latitude} or {@linkplain Longitude},
-     * and the class is immutable.  If that were to change, we need to know that DistanceCalculator detects
-     * nulls, so this test uses Mockito to force a null to force Point to return a null.
-     */
-    @Test
-    void distance_nullLatitudePoint2() {
-        when(mockPoint.latitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> distance(Unit.KILOMETERS, point1, mockPoint));
-        assertEquals("Latitude 2 is null", e.getMessage());
-    }
-
-    /**
-     * {@linkplain Point}'s constructor doesn't allow null {@linkplain Latitude} or {@linkplain Longitude},
-     * and the class is immutable.  If that were to change, we need to know that DistanceCalculator detects
-     * nulls, so this test uses Mockito to force a null to force Point to return a null.
-     */
-    @Test
-    void distance_nullLongitudePoint1() {
-        when(mockPoint.longitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> distance(Unit.KILOMETERS, mockPoint, point2));
-        assertEquals("Longitude 1 is null", e.getMessage());
-    }
-
-    /**
-     * {@linkplain Point}'s constructor doesn't allow null {@linkplain Latitude} or {@linkplain Longitude},
-     * and the class is immutable.  If that were to change, we need to know that DistanceCalculator detects
-     * nulls, so this test uses Mockito to force a null to force Point to return a null.
-     */
-    @Test
-    void distance_nullLongitudePoint2() {
-        when(mockPoint.longitude()).thenReturn(null);
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> distance(Unit.KILOMETERS, point1, mockPoint));
-        assertEquals("Longitude 2 is null", e.getMessage());
+        assertEquals("point 0 is null", e.getMessage());
     }
 
     @Test
     void distance_centimeters() {
-        final Latitude lat1 = new Latitude(12.34);
-        final Longitude lon1 = new Longitude(56.78);
-
-        final Latitude lat2 = new Latitude(12.349);
-        final Longitude lon2 = new Longitude(56.78);
-
-        final Point point1 = new Point(lat1, lon1);
-        final Point point2 = new Point(lat2, lon2);
+        final Point point1 = new Point(new Latitude(12.34), new Longitude(56.78));
+        final Point point2 = new Point(new Latitude(12.349), new Longitude(56.78));
 
         final double distance = distance(Unit.CENTIMETERS, point1, point2);
-        assertEquals(100075.55964381338d, distance, fpDelta);
+        assertEquals(100075.43398010725d, distance, fpDelta);
+    }
+
+    @Test
+    void distance_overloadedMethodsReturnSameResult() {
+        final Point point1 = new Point(new Latitude(12.34), new Longitude(56.78));
+        final Point point2 = new Point(new Latitude(12.349), new Longitude(56.78));
+
+        final double distance = distance(Unit.CENTIMETERS, point1, point2);
+        assertEquals(100075.43398010725d, distance, fpDelta);
+        assertEquals(distance, DistanceCalculator.distance(Unit.CENTIMETERS, List.of(point1, point2)));
     }
 
     @Test
     void distance_inches() {
-        final Latitude lat1 = new Latitude(12.34);
-        final Longitude lon1 = new Longitude(56.78);
-
-        final Latitude lat2 = new Latitude(12.349);
-        final Longitude lon2 = new Longitude(56.78);
-
-        final Point point1 = new Point(lat1, lon1);
-        final Point point2 = new Point(lat2, lon2);
+        final Point point1 = new Point(new Latitude(12.34), new Longitude(56.78));
+        final Point point2 = new Point(new Latitude(12.349), new Longitude(56.78));
 
         final double distance = distance(Unit.INCHES, point1, point2);
-        assertEquals(39399.84790732897d, distance, fpDelta);
+        assertEquals(39399.798433402204d, distance, fpDelta);
     }
 
     @Test
     void distance_feet() {
         final double distance = distance(Unit.FEET, point1, point2);
-        assertEquals(1070813.1682907024d, distance, fpDelta);
+        assertEquals(1070811.8236831701d, distance, fpDelta);
     }
 
     @Test
     void distance_kilometers() {
         final double distance = distance(Unit.KILOMETERS, point1, point2);
-        assertEquals(326.3838536950061d, distance, fpDelta);
+        assertEquals(326.38344385863024d, distance, fpDelta);
     }
 
     @Test
     void distance_meters() {
         final double distance = distance(Unit.METERS, point1, point2);
-        assertEquals(326383.8536950061d, distance, fpDelta);
+        assertEquals(326383.44385863026d, distance, fpDelta);
     }
 
     @Test
     void distance_miles() {
         final double distance = distance(Unit.MILES, point1, point2);
-        assertEquals(202.80552429748153, distance, fpDelta);
+        assertEquals(202.80526963696403, distance, fpDelta);
     }
 
     @Test
     void distance_nauticalMiles() {
         final double distance = distance(Unit.NAUTICAL_MILES, point1, point2);
-        assertEquals(176.23318234071604d, distance, fpDelta);
+        assertEquals(176.23296104677658d, distance, fpDelta);
     }
 
     @Test
     void distance_usSurveyFeet() {
         final double distance = distance(Unit.US_SURVEY_FEET, point1, point2);
-        assertEquals(1070811.026664366d, distance, fpDelta);
+        assertEquals(1070809.6820595227d, distance, fpDelta);
     }
 
     @Test
     void distance_yards() {
         final double distance = distance(Unit.YARDS, point1, point2);
-        assertEquals(356937.7227635675d, distance, fpDelta);
+        assertEquals(356937.27456105675d, distance, fpDelta);
     }
 
     /**
@@ -235,34 +173,32 @@ class DistanceCalculatorTest {
      * for a plane or something, <strong>you're a complete fool.</strong>  Don't even think about doing this.
      * </p>
      *
-     * @see <a href="http://binged.it/1SPhHjq">Shortened trip URL</a>  - Who knows how long this will exist before Bing deletes it...
-     * @see <a href="http://www.bing.com/mapspreview?&ty=0&rtp=pos.35.048992_-118.987968_I-5%20N%2c%20Bakersfield%2c%20CA%2093307_I-5%20N%2c%20Bakersfield%2c%20CA%2093307__e_~pos.36.078312_-120.103737_I-5%20N%2c%20Huron%2c%20CA%2093234_I-5%20N%2c%20Huron%2c%20CA%2093234__e_&mode=d&u=0&tt=I-5%20N%2c%20Bakersfield%2c%20CA%2093307%20to%20I-5%20N%2c%20Huron%2c%20CA%2093234&tsts2=%2526ty%253d18%2526q%253d35.04899226103765%25252c-118.98797131369996%2526mb%253d36.379826~-121.444888~34.715083~-117.418399&tstt2=I-5%20N%2c%20Bakersfield%2c%20CA%2093307&tsts1=%2526ty%253d0%2526rtp%253dpos.35.048992_-118.987968_I-5%252520N%25252c%252520Bakersfield%25252c%252520CA%25252093307_I-5%252520N%25252c%252520Bakersfield%25252c%252520CA%25252093307__e_~pos.36.078312_-120.103737_I-5%252520N%25252c%252520Huron%25252c%252520CA%25252093234_I-5%252520N%25252c%252520Huron%25252c%252520CA%25252093234__e_%2526mode%253dd%2526u%253d0&tstt1=I-5%20N%2c%20Bakersfield%2c%20CA%2093307%20to%20I-5%20N%2c%20Huron%2c%20CA%2093234&tsts0=%2526ty%253d18%2526q%253d36.07831163070724%25252c-120.1037394074518%2526mb%253d36.084772~-120.119465~36.071852~-120.088008&tstt0=I-5%20N%2c%20Huron%2c%20CA%2093234&cp=36.078659~-120.107106&lvl=16&ftst=1&ftics=True&v=2&sV=1&form=S00027">Full trip URL</a> - Use this if the shortened URL doesn't work.  This URL is so ridiculous, there's no telling how long it will actually work before Bing changes the URL format.
+     * @see <a href="http://binged.it/1SPhHjq">Shortened trip URL</a>
+     * @see <a href="http://www.bing.com/mapspreview?&ty=0&rtp=pos.35.048992_-118.987968_I-5%20N%2c%20Bakersfield%2c%20CA%2093307_I-5%20N%2c%20Bakersfield%2c%20CA%2093307__e_~pos.36.078312_-120.103737_I-5%20N%2c%20Huron%2c%20CA%2093234_I-5%20N%2c%20Huron%2c%20CA%2093234__e_&mode=d&u=0&tt=I-5%20N%2c%20Bakersfield%2c%20CA%2093307%20to%20I-5%20N%2c%20Huron%2c%20CA%2093234&tsts2=%2526ty%253d18%2526q%253d35.04899226103765%25252c-118.98797131369996%2526mb%253d36.379826~-121.444888~34.715083~-117.418399&tstt2=I-5%20N%2c%20Bakersfield%2c%20CA%2093307&tsts1=%2526ty%253d0%2526rtp%253dpos.35.048992_-118.987968_I-5%252520N%25252c%252520Bakersfield%25252c%252520CA%25252093307_I-5%252520N%25252c%252520Bakersfield%25252c%252520CA%25252093307__e_~pos.36.078312_-120.103737_I-5%252520N%25252c%252520Huron%25252c%252520CA%25252093234_I-5%252520N%25252c%252520Huron%25252c%252520CA%25252093234__e_%2526mode%253dd%2526u%253d0&tstt1=I-5%20N%2c%20Bakersfield%2c%20CA%2093307%20to%20I-5%20N%2c%20Huron%2c%20CA%2093234&tsts0=%2526ty%253d18%2526q%253d36.07831163070724%25252c-120.1037394074518%2526mb%253d36.084772~-120.119465~36.071852~-120.088008&tstt0=I-5%20N%2c%20Huron%2c%20CA%2093234&cp=36.078659~-120.107106&lvl=16&ftst=1&ftics=True&v=2&sV=1&form=S00027">Full trip URL</a> - Use this if the shortened URL doesn't work.  This URL is so complicated, there's no telling whether it will continue to work, but it has for 11 years...
      */
     @Test
     void distance_interpolateActualTrip() {
-        Point[] points = new Point[20];
-        int idx = 0;
-
-        points[idx++] = new Point(new Latitude(35.048983d), new Longitude(-118.987977d));
-        points[idx++] = new Point(new Latitude(35.084629d), new Longitude(-119.025986d));
-        points[idx++] = new Point(new Latitude(35.110199d), new Longitude(-119.053642d));
-        points[idx++] = new Point(new Latitude(35.157555d), new Longitude(-119.106155d));
-        points[idx++] = new Point(new Latitude(35.167416d), new Longitude(-119.117012d));
-        points[idx++] = new Point(new Latitude(35.210117d), new Longitude(-119.163582d));
-        points[idx++] = new Point(new Latitude(35.250221d), new Longitude(-119.206154d));
-        points[idx++] = new Point(new Latitude(35.298851d), new Longitude(-119.258682d));
-        points[idx++] = new Point(new Latitude(35.314541d), new Longitude(-119.279282d));
-        points[idx++] = new Point(new Latitude(35.333168d), new Longitude(-119.304924d));
-        points[idx++] = new Point(new Latitude(35.494205d), new Longitude(-119.528030d));
-        points[idx++] = new Point(new Latitude(35.500153d), new Longitude(-119.534805d));
-        points[idx++] = new Point(new Latitude(35.570133d), new Longitude(-119.610878d));
-        points[idx++] = new Point(new Latitude(35.597832d), new Longitude(-119.637657d));
-        points[idx++] = new Point(new Latitude(35.607117d), new Longitude(-119.646233d));
-        points[idx++] = new Point(new Latitude(35.851257d), new Longitude(-119.829330d));
-        points[idx++] = new Point(new Latitude(35.974480d), new Longitude(-119.952690d));
-        points[idx++] = new Point(new Latitude(36.003834d), new Longitude(-119.981400d));
-        points[idx++] = new Point(new Latitude(36.028889d), new Longitude(-120.019310d));
-        points[idx] = new Point(new Latitude(36.078247d), new Longitude(-120.103787d));
+        final List<Point> points = List.of(
+            new Point(new Latitude(35.048983d), new Longitude(-118.987977d)),
+            new Point(new Latitude(35.084629d), new Longitude(-119.025986d)),
+            new Point(new Latitude(35.110199d), new Longitude(-119.053642d)),
+            new Point(new Latitude(35.157555d), new Longitude(-119.106155d)),
+            new Point(new Latitude(35.167416d), new Longitude(-119.117012d)),
+            new Point(new Latitude(35.210117d), new Longitude(-119.163582d)),
+            new Point(new Latitude(35.250221d), new Longitude(-119.206154d)),
+            new Point(new Latitude(35.298851d), new Longitude(-119.258682d)),
+            new Point(new Latitude(35.314541d), new Longitude(-119.279282d)),
+            new Point(new Latitude(35.333168d), new Longitude(-119.304924d)),
+            new Point(new Latitude(35.494205d), new Longitude(-119.528030d)),
+            new Point(new Latitude(35.500153d), new Longitude(-119.534805d)),
+            new Point(new Latitude(35.570133d), new Longitude(-119.610878d)),
+            new Point(new Latitude(35.597832d), new Longitude(-119.637657d)),
+            new Point(new Latitude(35.607117d), new Longitude(-119.646233d)),
+            new Point(new Latitude(35.851257d), new Longitude(-119.829330d)),
+            new Point(new Latitude(35.974480d), new Longitude(-119.952690d)),
+            new Point(new Latitude(36.003834d), new Longitude(-119.981400d)),
+            new Point(new Latitude(36.028889d), new Longitude(-120.019310d)),
+            new Point(new Latitude(36.078247d), new Longitude(-120.103787d)));
 
         final double distance = distance(Unit.MILES, points);
 


### PR DESCRIPTION
* Added an additional `distance` method to `DistanceCalulator`.  You can now pass a `List` of points rather than being required to use vararg/array
* `DistanceCalculator` has been updated to use [NASA's latest figure](https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html) for Earth's radius (revised down from 6371.008 km to 6371.0 km)
* Mockito is no longer a test dependency
* Fixed Spotbugs failure regarding newline platform independence